### PR TITLE
API Callback not fired when response data is incorrect

### DIFF
--- a/Example/ONVIFCamera/ViewController.swift
+++ b/Example/ONVIFCamera/ViewController.swift
@@ -91,9 +91,12 @@ class ViewController: UIViewController, UITextFieldDelegate {
                                                                            password: passwordTextField.text!),
                                      soapLicenseKey: Config.soapLicenseKey)
             }
-          
-            camera.getServices {
-                self.getDeviceInformation()
+                      
+            camera.getServices { (error) in
+                
+                if error == nil {
+                    self.getDeviceInformation()
+                }
             }
             
         } else if camera.state == .ReadyToPlay {


### PR DESCRIPTION
Bug Fixes 
When calling the GetServices API or any of the others, due to the Guard / Let condition , if data were incorrect, there as only one return. 

However the user who try to implement the SDK will face to an issue : No callback will be fired to him.

## Description
I added the default callback on every guard for the basic service
Then I added an error parameters for some service in order to the developer to be able to display an meaningful message to the user.

## Motivation and Context

It fix an issue discovered while trying to build an App for the ONVIF Challenge.

## How Has This Been Tested?

Just by calling the services and making sure that a callback is called everytime !

## Screenshots (if appropriate):
None